### PR TITLE
Fix empty character classes

### DIFF
--- a/src/generator/__tests__/generator-basic-test.js
+++ b/src/generator/__tests__/generator-basic-test.js
@@ -79,8 +79,16 @@ describe('generator-basic', () => {
     test(/[a-z0]/);
   });
 
+  it('empty positive character class', () => {
+    test(/[]/);
+  });
+
   it('negative character class', () => {
     test(/[^a-z0]/);
+  });
+
+  it('empty negative character class', () => {
+    test(/[^]/);
   });
 
   it('positive lookahead assertion', () => {

--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -63,8 +63,7 @@ const generator = {
   },
 
   CharacterClass(node) {
-    const expressions = node
-      .expressions
+    const expressions = (node.expressions || [])
       .map(node => gen(node))
       .join('');
 


### PR DESCRIPTION
I've fixed this way (in generator) to allow omitting `node.expressions = []` while traversing.