### PR TITLE
Coerce to string in `parse`

### DIFF
--- a/__tests__/integration-test.js
+++ b/__tests__/integration-test.js
@@ -74,4 +74,10 @@ describe('regexp-tree', () => {
     expect(re.test('Z')).toBe(true);
   });
 
+  it('calls `ToString` in `parse`', () => {
+    const reStr = '/m/m';
+    const ast = regexpTree.parse({toString: () => reStr});
+    expect(regexpTree.generate(ast)).toBe(reStr);
+  });
+
 });

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const regexpTree = {
    * @return Object AST
    */
   parse(regexp) {
-    return parser.parse(regexp);
+    return parser.parse(`${regexp}`);
   },
 
   /**


### PR DESCRIPTION
Closes #12.

I would argue than instead of adding another method, `parse` should do `ToString`.

- It is simpler for users of API, makes first contact with module more pleasant ("Unexpected end of input" error is not very helpful).
- Less bloat.
- Will make `traverse` API simpler (`traverseFromRegExp` does not look right).
- Very JavaScripty and feels natural.