### PR TITLE
add "None" type to generator which generates no code

### DIFF
--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -20,6 +20,10 @@ const generator = {
     return `/${gen(node.body)}/${node.flags}`;
   },
 
+  None(node) {
+    return '';
+  },
+
   Alternative(node) {
     return (node.expressions || [])
       .map(gen)


### PR DESCRIPTION
this allows transformations to simply set the type of a node to `"None"` instead of removing it, when it's sufficient to keep the dead nodes until `generate()`