### PR TITLE
add getParent() to NodePath

### DIFF
--- a/src/traverse/README.md
+++ b/src/traverse/README.md
@@ -52,3 +52,5 @@ Methods of the `NodePath`:
 * `update(nodeProps: Object)` - updates a node inline;
 * `getPreviousSibling()` - returns previous sibling path;
 * `getNextSibling()` - returns next sibling path;
+* `getChild(n: Number = 0)` - return `n`th child path;
+* `getParent()` - return parent path, for consistency, returns parentPath;

--- a/src/traverse/__tests__/node-path-test.js
+++ b/src/traverse/__tests__/node-path-test.js
@@ -287,21 +287,19 @@ describe('NodePath', () => {
   it('getParent/getChild', () => {
     const ast = parser.parse('/a(bc)d/');
 
-    //console.log(JSON.stringify(ast, null, '  '));
-
-    bodyPath = NodePath.getForNode(ast.body);
-    groupPath = bodyPath.getChild(1);
+    const bodyPath = NodePath.getForNode(ast.body);
+    const groupPath = bodyPath.getChild(1);
 
     expect(groupPath.node.type).toBe("Group");
     expect(groupPath.getParent()).toBe(bodyPath);
 
-    alterPath = groupPath.getChild();
+    const alterPath = groupPath.getChild();
 
     expect(alterPath.node.type).toBe("Alternative");
     expect(alterPath.getParent()).toBe(groupPath);
 
-    bCharPath = alterPath.getChild(0);
-    cCharPath = alterPath.getChild(1);
+    const bCharPath = alterPath.getChild(0);
+    const cCharPath = alterPath.getChild(1);
 
     expect(bCharPath.getParent()).toBe(alterPath);
     expect(cCharPath.getParent()).toBe(alterPath);

--- a/src/traverse/__tests__/node-path-test.js
+++ b/src/traverse/__tests__/node-path-test.js
@@ -281,6 +281,44 @@ describe('NodePath', () => {
     );
 
     expect(aCharPath.getNextSibling()).toBe(bCharPath);
+
+  });
+
+  it('getParent/getChild', () => {
+    const ast = parser.parse('/a(bc)d/');
+
+    //console.log(JSON.stringify(ast, null, '  '));
+
+    bodyPath = NodePath.getForNode(ast.body);
+    groupPath = bodyPath.getChild(1);
+
+    expect(groupPath.node.type).toBe("Group");
+    expect(groupPath.getParent()).toBe(bodyPath);
+
+    alterPath = groupPath.getChild();
+
+    expect(alterPath.node.type).toBe("Alternative");
+    expect(alterPath.getParent()).toBe(groupPath);
+
+    bCharPath = alterPath.getChild(0);
+    cCharPath = alterPath.getChild(1);
+
+    expect(bCharPath.getParent()).toBe(alterPath);
+    expect(cCharPath.getParent()).toBe(alterPath);
+
+    expect(bCharPath.getParent().getParent()).toBe(groupPath);
+    expect(cCharPath.getParent().getParent()).toBe(groupPath);
+
+    expect(groupPath.getChild()).toBe(alterPath);
+    expect(groupPath.getChild(0)).toBe(alterPath);
+    expect(groupPath.getChild(1)).toBe(null);
+
+    expect(groupPath.getChild().getChild(0)).toBe(bCharPath);
+    expect(groupPath.getChild().getChild(1)).toBe(cCharPath);
+
+    expect(groupPath.getChild()).toBe(alterPath);
+    expect(groupPath.getChild(0)).toBe(alterPath);
+    expect(groupPath.getChild(1)).toBe(null);
   });
 
 });

--- a/src/traverse/node-path.js
+++ b/src/traverse/node-path.js
@@ -113,6 +113,16 @@ class NodePath {
   }
 
   /**
+   * Returns parent.
+   */
+  getParent() {
+    if (!this.parent) {
+      return null;
+    }
+    return NodePath.getForNode(this.parent);
+  }
+
+  /**
    * Returns previous sibling.
    */
   getPreviousSibling() {

--- a/src/traverse/node-path.js
+++ b/src/traverse/node-path.js
@@ -123,6 +123,23 @@ class NodePath {
   }
 
   /**
+   * Returns nth child.
+   */
+  getChild(n = 0) {
+    if (this.node.expressions) {
+      return NodePath.getForNode(
+        this.node.expressions[n],
+        this,
+        "expressions",
+        n
+      );
+    } else if (this.node.expression && n == 0) {
+      return NodePath.getForNode(this.node.expression, this, "expression");
+    }
+    return null;
+  }
+
+  /**
    * Returns previous sibling.
    */
   getPreviousSibling() {

--- a/src/traverse/node-path.js
+++ b/src/traverse/node-path.js
@@ -116,10 +116,7 @@ class NodePath {
    * Returns parent.
    */
   getParent() {
-    if (!this.parent) {
-      return null;
-    }
-    return NodePath.getForNode(this.parent);
+    return this.parentPath;
   }
 
   /**


### PR DESCRIPTION
we need this
* to navigate to parent without knowing implementation details (NodePath, node.parent etc.)
* to have a consistent API