### PR TITLE
Add initial TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,19 +36,19 @@ declare namespace Node {
   }
 
   interface Disjunction extends Base<'Disjunction'> {
-    expressions: Expression[];
+    expressions: (Expression | null)[];
   }
 
   interface CapturingGroup extends Base<'Group'> {
     capturing: true;
     number: number;
     name?: string;
-    expression: Expression;
+    expression: Expression | null;
   }
 
   interface NoncapturingGroup extends Base<'Group'> {
     capturing: false;
-    expression: Expression;
+    expression: Expression | null;
   }
 
   type Group = CapturingGroup | NoncapturingGroup;
@@ -93,7 +93,7 @@ declare namespace Node {
   interface LookaroundAssertion extends Base<'Assertion'> {
     kind: 'Lookahead' | 'Lookbehind';
     negative?: true;
-    assertion: Expression;
+    assertion: Expression | null;
   }
 
   type Assertion = SimpleAssertion | LookaroundAssertion;
@@ -109,7 +109,7 @@ declare namespace Node {
     | Assertion;
 
   interface RegExp extends Base<'RegExp'> {
-    body: Expression;
+    body: Expression | null;
     flags: string;
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,121 @@
+declare namespace Node {
+  interface Base<T> {
+    type: T;
+    loc?: {
+      source: string;
+      start: number;
+      end: number;
+    };
+  }
+
+  interface SimpleChar extends Base<'Char'> {
+    value: string;
+    kind: 'simple';
+    escaped?: true;
+  }
+
+  interface SpecialChar extends Base<'Char'> {
+    value: string;
+    kind: 'meta' | 'control' | 'hex' | 'decimal' | 'oct' | 'unicode';
+  }
+
+  type Char = SimpleChar | SpecialChar;
+
+  interface ClassRange extends Base<'ClassRange'> {
+    from: Char;
+    to: Char;
+  }
+
+  interface CharacterClass extends Base<'CharacterClass'> {
+    negative?: true;
+    expressions: (Char | ClassRange)[];
+  }
+
+  interface Alternative extends Base<'Alternative'> {
+    expressions: Expression[];
+  }
+
+  interface Disjunction extends Base<'Disjunction'> {
+    expressions: Expression[];
+  }
+
+  interface CapturingGroup extends Base<'Group'> {
+    capturing: true;
+    number: number;
+    name?: string;
+    expression: Expression;
+  }
+
+  interface NoncapturingGroup extends Base<'Group'> {
+    capturing: false;
+    expression: Expression;
+  }
+
+  type Group = CapturingGroup | NoncapturingGroup;
+
+  interface NumericBackreference extends Base<'Backreference'> {
+    kind: 'number';
+    number: number;
+    reference: number;
+  }
+
+  interface NamedBackreference extends Base<'Backreference'> {
+    kind: 'name';
+    number: number;
+    reference: string;
+  }
+
+  type Backreference = NumericBackreference | NamedBackreference;
+
+  interface Repetition extends Base<'Repetition'> {
+    expression: Expression;
+    quantifier: Quantifier;
+  }
+
+  interface SimpleQuantifier extends Base<'Quantifier'> {
+    kind: '+' | '*';
+    greedy: boolean;
+  }
+
+  interface RangeQuantifier extends Base<'Quantifier'> {
+    kind: 'Range';
+    from: number;
+    to: number;
+    greedy: boolean;
+  }
+
+  type Quantifier = SimpleQuantifier | RangeQuantifier;
+
+  interface SimpleAssertion extends Base<'Assertion'> {
+    kind: '^' | '$' | '\\b' | '\\B';
+  }
+
+  interface LookaroundAssertion extends Base<'Assertion'> {
+    kind: 'Lookahead' | 'Lookbehind';
+    negative?: true;
+    assertion: Expression;
+  }
+
+  type Assertion = SimpleAssertion | LookaroundAssertion;
+
+  type Expression =
+    | Char
+    | CharacterClass
+    | Alternative
+    | Disjunction
+    | Group
+    | Backreference
+    | Repetition
+    | Assertion;
+
+  interface RegExp extends Base<'RegExp'> {
+    body: Expression;
+    flags: string;
+  }
+}
+
+interface ParserOptions {
+  captureLocations?: boolean;
+}
+
+export function parse(s: string | RegExp, options?: ParserOptions): Node.RegExp;


### PR DESCRIPTION
When published to npm, this will help TS developers to automatically get strong typings when importing a module.

Covering only parser for now as that's the most interesting for me, but I'm sure someone else can pick it up and add other APIs.

Semi-related to #34.