### PR TITLE
Add support for {0,} -> * in optimizer's quantifier-range-to-symbol transform

### DIFF
--- a/src/optimizer/transforms/__tests__/quantifier-range-to-symbol-transform-test.js
+++ b/src/optimizer/transforms/__tests__/quantifier-range-to-symbol-transform-test.js
@@ -10,6 +10,13 @@ const quantifierRangeToSymbol = require('../quantifier-range-to-symbol-transform
 
 describe('quantifier range to symbol', () => {
 
+  it('a{0,} -> a*', () => {
+    const re = transform(/[a-z]{0,}/, [
+      quantifierRangeToSymbol,
+    ]);
+    expect(re.toString()).toBe('/[a-z]*/');
+  });
+
   it('a{1,} -> a+', () => {
     const re = transform(/[a-z]{1,}/, [
       quantifierRangeToSymbol,

--- a/src/optimizer/transforms/quantifier-range-to-symbol-transform.js
+++ b/src/optimizer/transforms/quantifier-range-to-symbol-transform.js
@@ -9,6 +9,7 @@
  * A regexp-tree plugin to replace different range-based quantifiers
  * with their symbol equivalents.
  *
+ * a{0,} -> a*
  * a{1,} -> a+
  * a{1} -> a
  *
@@ -24,6 +25,9 @@ module.exports = {
       return;
     }
 
+    // a{0,} -> a*
+    rewriteOpenZero(path);
+
     // a{1,} -> a+
     rewriteOpenOne(path);
 
@@ -31,6 +35,17 @@ module.exports = {
     rewriteExactOne(path);
   }
 };
+
+function rewriteOpenZero(path) {
+  const {node} = path;
+
+  if (node.from !== 0 || node.to) {
+    return;
+  }
+
+  node.kind = '*';
+  delete node.from;
+}
 
 function rewriteOpenOne(path) {
   const {node} = path;


### PR DESCRIPTION
This adds support for `/a{0,}/` -> `/a*/` in Optimizer.