### PR TITLE
Optimizer: don't unescape \^ in character class

### DIFF
--- a/src/optimizer/__tests__/optimizer-integration-test.js
+++ b/src/optimizer/__tests__/optimizer-integration-test.js
@@ -27,7 +27,7 @@ describe('optimizer-integration-test', () => {
 
   it('preserve escape', () => {
     const original = /^[\^\*\$\(\)]\^\*\$\(\)\.\[\]\/\\$/;
-    const optimized = /^[^*$()]\^\*\$\(\)\.\[\]\/\\$/;
+    const optimized = /^[\^*$()]\^\*\$\(\)\.\[\]\/\\$/;
 
     expect(optimizer.optimize(original).toString())
       .toBe(optimized.toString());

--- a/src/optimizer/transforms/__tests__/char-escape-unescape-transform-test.js
+++ b/src/optimizer/transforms/__tests__/char-escape-unescape-transform-test.js
@@ -28,7 +28,7 @@ describe('\e -> e', () => {
     const re = transform(/[\e\*\(\]\ \^\$\-]\(\n/, [
       charUnescape,
     ]);
-    expect(re.toString()).toBe(/[e*(\] ^$\-]\(\n/.toString());
+    expect(re.toString()).toBe(/[e*(\] \^$\-]\(\n/.toString());
   });
 
 });

--- a/src/optimizer/transforms/char-escape-unescape-transform.js
+++ b/src/optimizer/transforms/char-escape-unescape-transform.js
@@ -38,13 +38,14 @@ function shouldUnescape(path) {
 }
 
 /**
- * \], \\, \-
+ * \], \\, \^, \-
  *
  * Note: \- always preserved to avoid `[a\-z]` turning into `[a-z]`.
+ * Note: \^ always preserved to avoid `[\^a]` turning into `[^a]`.
  * TODO: more sophisticated analisys.
  */
 function preservesInCharClass(value) {
-  return /[\]\\\\-]/.test(value);
+  return /[\]\\^-]/.test(value);
 }
 
 // Note: \{ and \} are always preserved to avoid `a\{2\}` turning


### PR DESCRIPTION
We don't want `/[\^a]/` to be optimized to `/[^a]/`.