### PR TITLE
Optimizer should run until it finds the best optimization

### DIFF
--- a/src/optimizer/__tests__/optimizer-integration-test.js
+++ b/src/optimizer/__tests__/optimizer-integration-test.js
@@ -73,4 +73,12 @@ describe('optimizer-integration-test', () => {
       .toBe(optimized.toString());
   });
 
+  it('finds the best optimization', () => {
+    const original = /a|a/;
+    const optimized = /a/;
+
+    expect(optimizer.optimize(original).toString())
+      .toBe(optimized.toString());
+  });
+
 });

--- a/src/optimizer/index.js
+++ b/src/optimizer/index.js
@@ -26,11 +26,19 @@ module.exports = {
    *   /\w+e+/
    */
   optimize(regexp) {
+    let prevResult;
     let result;
-    optimizationTransforms.forEach(transformer => {
-      result = transform.transform(regexp, transformer);
-      regexp = result.getAST();
-    });
+    do {
+      if (result) {
+        prevResult = result.toRegExp().toString();
+        regexp = result.toRegExp();
+      }
+      optimizationTransforms.forEach(transformer => {
+        result = transform.transform(regexp, transformer);
+        regexp = result.getAST();
+      });
+    } while (result.toRegExp().toString() !== prevResult);
+
     return result;
   },
 };


### PR DESCRIPTION
Currently, optimizing `/a|a/` gives `/[a]/` and optimizing again `/[a]/` gives `/a/`.
We should get the most optimized result directly.

This PR lets the optimizer run until it finds the best optimization. The drawback is that it has to run minimum twice to know...