### PR TITLE
Optimizer: remove unnecessary groups

### DIFF
--- a/src/optimizer/transforms/__tests__/ungroup-transform-test.js
+++ b/src/optimizer/transforms/__tests__/ungroup-transform-test.js
@@ -1,0 +1,67 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017-present Dmitry Soshnikov <dmitry.soshnikov@gmail.com>
+ */
+
+'use strict';
+
+const {transform} = require('../../../transform');
+const ungroup = require('../ungroup-transform');
+
+describe('ungroup', () => {
+
+  it('ungroups simple groups', () => {
+    const re = transform(/(?:a)/, [
+      ungroup,
+    ]);
+    expect(re.toString()).toBe('/a/');
+
+    const re2 = transform(/a(?:[\da]b)c/, [
+      ungroup,
+    ]);
+    expect(re2.toString()).toBe('/a[\\da]bc/');
+  });
+
+  it('ungroups disjunctions if top-level', () => {
+    const re = transform(/(?:ab|bc)/, [
+      ungroup,
+    ]);
+    expect(re.toString()).toBe('/ab|bc/');
+  });
+
+  it('does not ungroup other disjunctions', () => {
+    const re = transform(/^(?:ab|bc)/, [
+      ungroup,
+    ]);
+    expect(re.toString()).toBe('/^(?:ab|bc)/');
+  });
+
+  it('ungroups groups with quantifier if child is a Char', () => {
+    const re = transform(/(?:a)+/, [
+      ungroup,
+    ]);
+    expect(re.toString()).toBe('/a+/');
+  });
+
+  it('ungroups groups with quantifier if child is a CharacterClass', () => {
+    const re = transform(/(?:[ab])+/, [
+      ungroup,
+    ]);
+    expect(re.toString()).toBe('/[ab]+/');
+  });
+
+  it('does not ungroup groups with quantifier otherwise', () => {
+    const re = transform(/(?:ab)+/, [
+      ungroup,
+    ]);
+    expect(re.toString()).toBe('/(?:ab)+/');
+  });
+
+  it('does not ungroup capturing groups', () => {
+    const re = transform(/(a)/, [
+      ungroup,
+    ]);
+    expect(re.toString()).toBe('/(a)/');
+  });
+
+});

--- a/src/optimizer/transforms/index.js
+++ b/src/optimizer/transforms/index.js
@@ -25,5 +25,8 @@ module.exports = [
   require('./char-escape-unescape-transform'),
 
   // (a|b|c) -> [abc]
-  require('./group-single-chars-to-char-class')
+  require('./group-single-chars-to-char-class'),
+
+  // (?:a) -> a
+  require('./ungroup-transform')
 ];

--- a/src/optimizer/transforms/ungroup-transform.js
+++ b/src/optimizer/transforms/ungroup-transform.js
@@ -1,0 +1,41 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017-present Dmitry Soshnikov <dmitry.soshnikov@gmail.com>
+ */
+
+'use strict';
+
+/**
+ * A regexp-tree plugin to remove unnecessary groups.
+ *
+ * /(?:a)/ -> /a/
+ */
+
+module.exports = {
+  Group(path) {
+    const {node, parent} = path;
+    const childPath = path.getChild();
+
+    if (node.capturing) {
+      return;
+    }
+
+    if (
+      childPath &&
+      childPath.node.type === 'Disjunction' &&
+      parent.type !== 'RegExp'
+    ) {
+      return;
+    }
+
+    if (
+      parent.type === 'Repetition' &&
+      childPath.node.type !== 'Char' &&
+      childPath.node.type !== 'CharacterClass'
+    ) {
+      return;
+    }
+
+    path.replace(childPath.node);
+  }
+};


### PR DESCRIPTION
This transform removes unnecessary groups:

`/a(?:bc)d/` -> `/abcd/`
`/(?:ab|bc)/` -> `/ab|bc/`
`/(?:a)+/` -> `/a+/`

It does not remove capturing groups, nor disjunctions other than top-level ones, nor complex groups with quantifier:
`/a(bc)d/`, `/a(?:ab|bc)d/`, `/(?:ab)+/` are left unchanged.