### PR TITLE
Optimizer: don't throw errors on empty groups

### DIFF
--- a/src/optimizer/transforms/__tests__/disjunction-remove-duplicates-transform-test.js
+++ b/src/optimizer/transforms/__tests__/disjunction-remove-duplicates-transform-test.js
@@ -50,4 +50,11 @@ describe('(ab|bc|ab) -> (ab|bc)', () => {
     expect(re2.toString()).toBe('/(?:ab|bc)/');
   });
 
+  it('handles empty parts', () => {
+    const re = transform(/a|b|||/, [
+      disjunctionRemoveDuplicates
+    ]);
+    expect(re.toString()).toBe('/a|b|/');
+  });
+
 });

--- a/src/optimizer/transforms/__tests__/group-single-chars-to-char-class-test.js
+++ b/src/optimizer/transforms/__tests__/group-single-chars-to-char-class-test.js
@@ -59,4 +59,11 @@ describe('(a|b|c) -> ([abc])', () => {
     expect(re.toString()).toBe('/(a|b|no)/');
   });
 
+  it('has no effet on empty values', () => {
+    const re = transform(/(a|b|)/, [
+      singleCharsGroupToCharClass,
+    ]);
+    expect(re.toString()).toBe('/(a|b|)/');
+  });
+
 });

--- a/src/optimizer/transforms/__tests__/ungroup-transform-test.js
+++ b/src/optimizer/transforms/__tests__/ungroup-transform-test.js
@@ -64,4 +64,11 @@ describe('ungroup', () => {
     expect(re.toString()).toBe('/(a)/');
   });
 
+  it('does not ungroup empty groups', () => {
+    const re = transform(/(?:)+/, [
+      ungroup,
+    ]);
+    expect(re.toString()).toBe('/(?:)+/');
+  });
+
 });

--- a/src/optimizer/transforms/disjunction-remove-duplicates-transform.js
+++ b/src/optimizer/transforms/disjunction-remove-duplicates-transform.js
@@ -25,7 +25,7 @@ module.exports = {
     const uniqueNodesMap = {};
 
     const parts = disjunctionToList(node).filter(part => {
-      const encoded = NodePath.getForNode(part).jsonEncode();
+      const encoded = part ? NodePath.getForNode(part).jsonEncode() : 'null';
 
       // Already recorded this part, filter out.
       if (uniqueNodesMap.hasOwnProperty(encoded)) {

--- a/src/optimizer/transforms/group-single-chars-to-char-class.js
+++ b/src/optimizer/transforms/group-single-chars-to-char-class.js
@@ -60,6 +60,11 @@ const handlers = {
 };
 
 function shouldProcess(expression, charset) {
+  if (!expression) {
+    // Abort on empty disjunction part
+    return false;
+  }
+
   const {type} = expression;
 
   if (type === 'Disjunction') {

--- a/src/optimizer/transforms/ungroup-transform.js
+++ b/src/optimizer/transforms/ungroup-transform.js
@@ -16,12 +16,11 @@ module.exports = {
     const {node, parent} = path;
     const childPath = path.getChild();
 
-    if (node.capturing) {
+    if (node.capturing || !childPath) {
       return;
     }
 
     if (
-      childPath &&
       childPath.node.type === 'Disjunction' &&
       parent.type !== 'RegExp'
     ) {


### PR DESCRIPTION
This PR prevents the optimizer from throwing errors when handling empty groups or empty parts:

Optimizing `/a(?:)b/` used to throw in the `ungroup` transform. Now it leaves the regexp as it is.
Optimizing `/a||/` used to throw in the `disjunction-remove-duplicates` transform. Now it handles it properly and optimizes as `/a|/`.
Optimizing `/a|b|/` used to throw in the `group-single-chars-to-char-class` transform. Now it leaves the regexp as it is.

In the last case, I wonder if `[ab]?` would be an appropriate optimization. What is your opinion on this @DmitrySoshnikov ?

Also, I intend to add a specific transform to handle empty (non-capturing) groups at some point.
