### PR TITLE
Traverse: allow explicit stop of the traversal when using catch-all handler

### DIFF
--- a/src/traverse/index.js
+++ b/src/traverse/index.js
@@ -183,7 +183,11 @@ module.exports = {
             } else {
               // A path/node can be removed by some previous handler.
               if (!nodePath.isRemoved()) {
-                handler['*'](nodePath);
+                const handlerResult = handler['*'](nodePath);
+                // Explicitly stop traversal.
+                if (handlerResult === false) {
+                  return false;
+                }
               }
             }
           }


### PR DESCRIPTION
This is just to be consistent with per-node handlers.