### PR TITLE
Traverse: Delete node from NodePath registry when removed

### DIFF
--- a/src/traverse/node-path.js
+++ b/src/traverse/node-path.js
@@ -122,6 +122,7 @@ class NodePath {
     if (this.isRemoved()) {
       return;
     }
+    NodePath.registry.delete(this.node);
 
     this.node = null;
 


### PR DESCRIPTION
This fixes a weird bug I had with nodes existing in Registry being `null`.