### PR TITLE
Optimizer: Escape $ . / { } | in char-class-to-single-char transform

### DIFF
--- a/src/optimizer/transforms/char-class-to-single-char-transform.js
+++ b/src/optimizer/transforms/char-class-to-single-char-transform.js
@@ -67,6 +67,8 @@ function getInverseMeta(value) {
     : value.toLowerCase();
 }
 
+// Note: \{ and \} are always preserved to avoid `a[{]2[}]` turning
+// into `a{2}`.
 function shouldEscape(value) {
-  return /[*\[()+?]/.test(value);
+  return /[*[()+?$./{}|]/.test(value);
 }


### PR DESCRIPTION
The `char-class-to-single-char` transform must escape `$`, `.`, `/`, `{`, `}` and `|` when turning them into single chars.

`/[$]/`-> `/\$/`

Also, I wondered about the `$` char in thoses regexps: [L61](https://github.com/DmitrySoshnikov/regexp-tree/blob/master/src/optimizer/transforms/char-class-to-single-char-transform.js#L61) and [L65](https://github.com/DmitrySoshnikov/regexp-tree/blob/master/src/optimizer/transforms/char-class-to-single-char-transform.js#L65). What is it for?