### PR TITLE
Transform: Prevent disjunctionToList from throwing on /|/

### DIFF
--- a/src/transform/__tests__/transform-utils-test.js
+++ b/src/transform/__tests__/transform-utils-test.js
@@ -20,6 +20,15 @@ describe('transform-utils', () => {
     ]);
   });
 
+  it('handles empty parts', () => {
+    const disjunction = parser.parse('/|/').body;
+    const list = transformUtils.disjunctionToList(disjunction);
+    expect(list).toEqual([
+      disjunction.left, // null
+      disjunction.right // null
+    ]);
+  });
+
   it('disjunctionToList', () => {
     const list = [
       {type: 'Char', value: 'a', kind: 'simple', codePoint: 97, symbol: 'a'},

--- a/src/transform/utils.js
+++ b/src/transform/utils.js
@@ -19,7 +19,7 @@ function disjunctionToList(node) {
 
   const list = [];
 
-  if (node.left.type === 'Disjunction') {
+  if (node.left && node.left.type === 'Disjunction') {
     list.push(...disjunctionToList(node.left), node.right);
   } else {
     list.push(node.left, node.right);


### PR DESCRIPTION
This PR prevents `disjunctionToList` from throwing an error when processing `/|/`.