### PR TITLE
Optimizer: Add whitelist parameter to optimize()

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,8 +120,8 @@ const regexpTree = {
    *
    * @return TransformResult object
    */
-  optimize(regexp) {
-    return optimizer.optimize(regexp);
+  optimize(regexp, whitelist) {
+    return optimizer.optimize(regexp, whitelist);
   },
 
   /**

--- a/src/optimizer/__tests__/optimizer-integration-test.js
+++ b/src/optimizer/__tests__/optimizer-integration-test.js
@@ -81,4 +81,12 @@ describe('optimizer-integration-test', () => {
       .toBe(optimized.toString());
   });
 
+  it('applies whitelist only', () => {
+    const original = '/(?:[a])/';
+    const optimized = '/[a]/';
+
+    expect(optimizer.optimize(original, ['ungroup']).toString())
+      .toBe(optimized.toString());
+  });
+
 });

--- a/src/optimizer/index.js
+++ b/src/optimizer/index.js
@@ -25,7 +25,11 @@ module.exports = {
    *
    *   /\w+e+/
    */
-  optimize(regexp) {
+  optimize(regexp, transformsWhitelist = []) {
+    const transformToApply = transformsWhitelist.length > 0
+      ? transformsWhitelist
+      : Object.keys(optimizationTransforms);
+
     let prevResult;
     let result;
     do {
@@ -33,7 +37,18 @@ module.exports = {
         prevResult = result.toRegExp().toString();
         regexp = result.toRegExp();
       }
-      optimizationTransforms.forEach(transformer => {
+      transformToApply.forEach(transformName => {
+
+        if (!optimizationTransforms.hasOwnProperty(transformName)) {
+          throw new Error(
+            `Unknown optimization-transform: ${transformName}. ` +
+            `Available transforms are: ` +
+            Object.keys(optimizationTransforms).join(', ')
+          );
+        }
+
+        const transformer = optimizationTransforms[transformName];
+
         result = transform.transform(regexp, transformer);
         regexp = result.getAST();
       });

--- a/src/optimizer/transforms/index.js
+++ b/src/optimizer/transforms/index.js
@@ -5,37 +5,37 @@
 
 'use strict';
 
-module.exports = [
+module.exports = {
   // [\d\d] -> [\d]
-  require('./char-class-remove-duplicates-transform'),
+  'charClassRemoveDuplicates': require('./char-class-remove-duplicates-transform'),
 
   // a{1,2}a{2,3} -> a{3,5}
-  require('./quantifiers-merge-transform'),
+  'quantifiersMerge': require('./quantifiers-merge-transform'),
 
   // a{1,} -> a+, a{3,3} -> a{3}, a{1} -> a
-  require('./quantifier-range-to-symbol-transform'),
+  'quantifierRangeToSymbol': require('./quantifier-range-to-symbol-transform'),
 
   // [0-9] -> [\d]
-  require('./char-class-to-meta-transform'),
+  'charClassToMeta': require('./char-class-to-meta-transform'),
 
   // [\d] -> \d, [^\w] -> \W
-  require('./char-class-to-single-char-transform'),
+  'charClassToSingleChar': require('./char-class-to-single-char-transform'),
 
   // \e -> e
-  require('./char-escape-unescape-transform'),
+  'charEscapeUnescape': require('./char-escape-unescape-transform'),
 
   // (ab|ab) -> (ab)
-  require('./disjunction-remove-duplicates-transform'),
+  'disjunctionRemoveDuplicates': require('./disjunction-remove-duplicates-transform'),
 
   // (a|b|c) -> [abc]
-  require('./group-single-chars-to-char-class'),
+  'groupSingleCharsToCharClass': require('./group-single-chars-to-char-class'),
 
   // (?:)a -> a
-  require('./remove-empty-group-transform'),
+  'removeEmptyGroup': require('./remove-empty-group-transform'),
 
   // (?:a) -> a
-  require('./ungroup-transform'),
+  'ungroup': require('./ungroup-transform'),
 
   // abcabcabc -> (?:abc){3}
-  require('./combine-repeating-patterns-transform')
-];
+  'combineRepeatingPatterns': require('./combine-repeating-patterns-transform')
+};


### PR DESCRIPTION
This PR adds a `whitelist` parameter to the `optimize` method, as suggested in #81.

This could be a first step towards a list of optional ("loose") transforms that can only be performed when explicitely added to the whitelist.

I based this exactly on the compat-transpiler behaviour.
Alternatively, since it might be tedious to list all optimization transforms, we might want to consider using an object instead, with transform names as keys and booleans as values.