### PR TITLE
Optimizer: Remove $ from list of metas in char-class-to-single-car transform

### DIFF
--- a/src/optimizer/transforms/char-class-to-single-char-transform.js
+++ b/src/optimizer/transforms/char-class-to-single-char-transform.js
@@ -58,11 +58,11 @@ function isAppropriateChar(node) {
 }
 
 function isMeta(value) {
-  return /^\\[dwsDWS$]/.test(value);
+  return /^\\[dwsDWS]$/.test(value);
 }
 
 function getInverseMeta(value) {
-  return /[dws$]/.test(value)
+  return /[dws]/.test(value)
     ? value.toUpperCase()
     : value.toLowerCase();
 }


### PR DESCRIPTION
Following the discussion in #108, I'm pretty sure this `$` character is a typo. I can't think of any use case where we'd want to consider `$` as a meta character that can be inversed.