### PR TITLE
Optimizer: convert char class to \w differently depending on i and u flags

### DIFF
--- a/src/optimizer/transforms/__tests__/char-class-to-meta-transform-test.js
+++ b/src/optimizer/transforms/__tests__/char-class-to-meta-transform-test.js
@@ -24,6 +24,20 @@ describe('char-class-to-meta', () => {
     expect(re.toString()).toBe('/[\\w$]/');
   });
 
+  it('replaces word ranges when regexp has i flag', () => {
+    const re = transform(/[0-9a-z_$]/i, [
+      charClassToMeta,
+    ]);
+    expect(re.toString()).toBe('/[\\w$]/i');
+  });
+
+  it('replaces word ranges when regexp has i and u flags', () => {
+    const re = transform(/[\da-zA-Z_\u017F\u212A$]/iu, [
+      charClassToMeta,
+    ]);
+    expect(re.toString()).toBe('/[\\w$]/iu');
+  });
+
   it('whitespace ranges', () => {
     const re = transform(/[ \t\r\n\f]/, [
       charClassToMeta,

--- a/src/traverse/index.js
+++ b/src/traverse/index.js
@@ -150,7 +150,7 @@ module.exports = {
     // Allow handlers to initializer themselves.
     handlers.forEach(handler => {
       if (typeof handler.init === 'function') {
-        handler.init();
+        handler.init(ast);
       }
     });
 


### PR DESCRIPTION
The meaning of `\w` is extended when regexp has `i` and `u` flags so we should not do the optimization in this case.