### PR TITLE
Optimizer: Don't throw on new syntax

### DIFF
--- a/src/optimizer/index.js
+++ b/src/optimizer/index.js
@@ -34,8 +34,8 @@ module.exports = {
     let result;
     do {
       if (result) {
-        prevResult = result.toRegExp().toString();
-        regexp = result.toRegExp();
+        prevResult = result.toString();
+        regexp = prevResult;
       }
       transformToApply.forEach(transformName => {
 
@@ -52,7 +52,7 @@ module.exports = {
         result = transform.transform(regexp, transformer);
         regexp = result.getAST();
       });
-    } while (result.toRegExp().toString() !== prevResult);
+    } while (result.toString() !== prevResult);
 
     return result;
   },


### PR DESCRIPTION
Optimizer used to throw an error when used with regexps containing new syntax (like named captures or the `x` flag), since #101 was merged.

It was because I made the Transformer generate an actual RegExp instead of using a string representation. This PR fixes it!