### PR TITLE
Optimizer: Combine chars sequences into class ranges in char-class-classranges-merge transform

### DIFF
--- a/src/optimizer/transforms/__tests__/char-class-classranges-merge-transform-test.js
+++ b/src/optimizer/transforms/__tests__/char-class-classranges-merge-transform-test.js
@@ -122,4 +122,38 @@ describe('char-class-classranges-merge', () => {
     expect(re.toString()).toBe('/[\\u{1F680}-\\ud83d\\ude9b]/u');
   });
 
+  it('combines sequential chars into class ranges', () => {
+    let re = transform(/[facbdemlpqno]/, [
+      charClassClassrangesMerge,
+    ]);
+    expect(re.toString()).toBe('/[a-fl-q]/');
+
+    re = transform(/[\u0014\u0015\u0016]/, [
+      charClassClassrangesMerge,
+    ]);
+    expect(re.toString()).toBe('/[\\u0014-\\u0016]/');
+
+    re = transform(/[a\u0062c\u0064]/, [
+      charClassClassrangesMerge,
+    ]);
+    expect(re.toString()).toBe('/[a-\\u0064]/');
+
+    re = transform(/[a\u{62}c\u{64}]/u, [
+      charClassClassrangesMerge,
+    ]);
+    expect(re.toString()).toBe('/[a-\\u{64}]/u');
+
+    re = transform(/[\ud83d\ude88\ud83d\ude89\ud83d\ude8a]/u, [
+      charClassClassrangesMerge,
+    ]);
+    expect(re.toString()).toBe('/[\\ud83d\\ude88-\\ud83d\\ude8a]/u');
+  });
+
+  it('does not combine sequential chars that are nor in \\w nor number-coded', () => {
+    const re = transform(/[<=>?]/, [
+      charClassClassrangesMerge,
+    ]);
+    expect(re.toString()).toBe('/[<=>?]/');
+  });
+
 });


### PR DESCRIPTION
This PR updates the char-class-classranges-merge transform to handle sequences of chars:

`/[abcdef]/` -> `/[a-f]/`

For the sake of readability, I chose to only merge chars being in `\w` or being coded (either unicode, hex, octal or decimal). I'm not sure about this choice though.

Should the optimizer transform `/[<=>?]/` into `/[<-?]/`?