### PR TITLE
Optimizer: When u flag is set, convert surrogate pairs to single unicode code point

### DIFF
--- a/src/optimizer/transforms/__tests__/char-surrogate-pair-to-single-unicode-transform-test.js
+++ b/src/optimizer/transforms/__tests__/char-surrogate-pair-to-single-unicode-transform-test.js
@@ -1,0 +1,27 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017-present Dmitry Soshnikov <dmitry.soshnikov@gmail.com>
+ */
+
+'use strict';
+
+const {transform} = require('../../../transform');
+const charSurrogatePairToSingleUnicode = require('../char-surrogate-pair-to-single-unicode-transform');
+
+describe('\\ud83d\\ude80 -> \\u{1f680}', () => {
+
+  it('\\ud83d\\ude80 -> \\u{1f680}', () => {
+    const re = transform(/\ud83d\ude80/u, [
+      charSurrogatePairToSingleUnicode
+    ]);
+    expect(re.toString()).toBe('/\\u{1f680}/u');
+  });
+
+  it('does not run when unicode flag is absent', () => {
+    const re = transform(/\ud83d\ude80/, [
+      charSurrogatePairToSingleUnicode
+    ]);
+    expect(re.toString()).toBe('/\\ud83d\\ude80/');
+  });
+
+});

--- a/src/optimizer/transforms/char-surrogate-pair-to-single-unicode-transform.js
+++ b/src/optimizer/transforms/char-surrogate-pair-to-single-unicode-transform.js
@@ -1,0 +1,25 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2017-present Dmitry Soshnikov <dmitry.soshnikov@gmail.com>
+ */
+
+'use strict';
+
+/**
+ * A regexp-tree plugin to transform surrogate pairs into single unicode code point
+ *
+ * \ud83d\ude80 -> \u{1f680}
+ */
+module.exports = {
+  shouldRun(ast) {
+    return ast.flags.includes('u');
+  },
+  Char(path) {
+    const {node} = path;
+    if (node.kind !== 'unicode' || !node.isSurrogatePair || isNaN(node.codePoint)) {
+      return;
+    }
+    node.value = `\\u{${node.codePoint.toString(16)}}`;
+    delete node.isSurrogatePair;
+  }
+};

--- a/src/optimizer/transforms/index.js
+++ b/src/optimizer/transforms/index.js
@@ -6,6 +6,9 @@
 'use strict';
 
 module.exports = {
+  // \ud83d\ude80 -> \u{1f680}
+  'charSurrogatePairToSingleUnicode': require('./char-surrogate-pair-to-single-unicode-transform'),
+
   // [\d\d] -> [\d]
   'charClassRemoveDuplicates': require('./char-class-remove-duplicates-transform'),
 


### PR DESCRIPTION
`/\ud83d\ude80/u` -> `/\u{1f680}/u`