### PR TITLE
WIP: Number nested groups correctly

### DIFF
--- a/src/parser/__tests__/parser-basic-test.js
+++ b/src/parser/__tests__/parser-basic-test.js
@@ -441,6 +441,57 @@ describe('basic', () => {
       },
       flags: ''
     });
+
+    expect(re('/(((a)b)c)/')).toEqual({
+      type: 'RegExp',
+      body: {
+        type: 'Group',
+        capturing: true,
+        number: 1,
+        expression: {
+          type: 'Alternative',
+          expressions: [
+            {
+              type: 'Group',
+              capturing: true,
+              number: 2,
+              expression: {
+                type: 'Alternative',
+                expressions: [
+                  {
+                    type: 'Group',
+                    capturing: true,
+                    number: 3,
+                    expression: {
+                      type: 'Char',
+                      value: 'a',
+                      kind: 'simple',
+                      symbol: 'a',
+                      codePoint: 97
+                    }
+                  },
+                  {
+                    type: 'Char',
+                    value: 'b',
+                    kind: 'simple',
+                    symbol: 'b',
+                    codePoint: 98
+                  }
+                ]
+              }
+            },
+            {
+              type: 'Char',
+              value: 'c',
+              kind: 'simple',
+              symbol: 'c',
+              codePoint: 99
+            }
+          ]
+        }
+      },
+      flags: ''
+    });
   });
 
   it('empty group', () => {

--- a/src/parser/__tests__/parser-basic-test.js
+++ b/src/parser/__tests__/parser-basic-test.js
@@ -381,7 +381,7 @@ describe('basic', () => {
     );
   });
 
-  it.only('named unicode name', () => {
+  it('named unicode name', () => {
     expect(() => parser.parse('/(?<\\u{41}\\u0042>)/')).toThrowError(
       new SyntaxError(
         `invalid group Unicode name "\\u{41}\\u0042", use \`u\` flag.`
@@ -969,7 +969,7 @@ describe('basic', () => {
     expect(backspace.kind).toBe('meta');
   });
 
-  it('unicode', () => {
+  it.skip('unicode', () => {
     expect(re(/\u003B/).body).toEqual({
       type: 'Char',
       value: '\\u003B',

--- a/src/parser/regexp.bnf
+++ b/src/parser/regexp.bnf
@@ -170,12 +170,56 @@ GROUP_NAME              ([\w$]|\\'u'[0-9a-fA-F]{4}|\\'u{'[0-9a-fA-F]{1,}'}')+
 %{
 
 /**
- * Tracks capturing groups.
+ * The parsing pass resolves nodes in depth-first order.
+ * Depth-first parsing introduces difficulties that must be
+ * resolved in a subsequent pass.
+ * - Create a new PostParsingPass for each such pass.
+ * - Store the appropriate nodes in each PPP during parsing.
  */
-let capturingGroupsCount = 0;
+
+function PostParsingPass(cb) {
+	return {
+		nodes: [],
+		cb: cb
+	};
+}
+// Passes will be applied in left-to-right list order.
+let postParsingPasses = [];
 
 /**
- * Tracks named groups.
+ * groupRenumberingPass:
+ *   1. Nested capturing groups would receive inverted numbers if
+ *      we assigned numbers during parsing.
+ *   2. For the same reason, at parse-time it is hard to tell whether
+ *      a backreference refers to an already-parsed group.
+ */
+
+let groupRenumberingPass = PostParsingPass(function renumber() {
+	let nextGroupNumber = 1;
+	groupRenumberingPass.nodes.forEach((node) => {
+    // Capturing group: assign the next number.
+		if (node.type === 'Group' && node.capturing) {
+			node.number = nextGroupNumber;
+			nextGroupNumber++;
+		}
+    // Backreference: keep if we've seen the group number, or convert to Char.
+    else if (node.type === 'Backreference') {
+      if (node.kind === 'number') {
+        if (nextGroupNumber <= node.number) {
+          // Reference to a not-yet-seen group.
+          // Convert to a Char.
+          node = Char(text, 'decimal', textLoc);
+        }
+      }
+    }
+	});
+});
+postParsingPasses.push(groupRenumberingPass);
+
+/**
+ * Dictionary of names of named groups seen so far.
+ * Tracking this lets us identify references to the
+ * already-seen named groups in PreliminaryNamedGroupRef().
  */
 let namedGroups = {};
 
@@ -186,7 +230,6 @@ let parsingString = '';
 
 yyparse.onParseBegin = (string, lexer) => {
   parsingString = string;
-  capturingGroupsCount = 0;
   namedGroups = {};
 
   const lastSlash = string.lastIndexOf('/');
@@ -341,22 +384,24 @@ function checkFlags(flags) {
 }
 
 /**
- * Parses patterns like \1, \2, etc. either as a backreference
- * to a group, or a deciaml char code.
+ * Parses patterns like \1, \2, etc.
+ * In the parsing pass we interpret them as a group ref.
  */
-function GroupRefOrDecChar(text, textLoc) {
+function PreliminaryGroupRef(text, textLoc) {
   const reference = Number(text.slice(1));
 
-  if (reference > 0 && reference <= capturingGroupsCount) {
-    return Node({
-      type: 'Backreference',
-      kind: 'number',
-      number: reference,
-      reference,
-    }, textLoc);
-  }
+  const node = Node({
+    type: 'Backreference',
+    kind: 'number',
+    number: reference,
+    reference,
+  }, textLoc);
 
-  return Char(text, 'decimal', textLoc);
+  // In the renumbering pass we may decide this should be
+  // converted to a decimal char code.
+  groupRenumberingPass.nodes.push(node);
+
+  return node;
 }
 
 /**
@@ -378,23 +423,28 @@ function validateUnicodeGroupName(name, state) {
 }
 
 /**
- * Extracts from `\k<foo>` pattern either a backreference
- * to a named capturing group (if it presents), or parses it
- * as a list of char: `\k`, `<`, `f`, etc.
+ * Extracts from `\k<foo>` pattern as a backreference
+ * to a named capturing group.
  */
-function NamedGroupRefOrChars(text, textLoc) {
+function PreliminaryNamedGroupRef(text, textLoc) {
   const groupName = text.slice(3, -1);
 
   if (namedGroups.hasOwnProperty(groupName)) {
-    return Node({
+    const node = Node({
       type: 'Backreference',
       kind: 'name',
-      number: namedGroups[groupName],
+      number: -1,
       reference: groupName,
     }, textLoc);
+
+    // The assigned number may be incorrect.
+    groupRenumberingPass.nodes.push(node);
+
+    return node;
   }
 
-  // Else `\k<foo>` should be parsed as a list of `Char`s.
+  // If we have not yet seen this named group, then
+  // `\k<foo>` should be parsed as a list of `Char`s.
   // This is really a 0.01% edge case, but we should handle it.
 
   let startOffset = null;
@@ -527,6 +577,14 @@ RegExp
         body: $2,
         flags: checkFlags($4),
       }, loc(@1, @4 || @3))
+
+      // Apply PostParsingPass's.
+      let i = 0;
+      postParsingPasses.forEach((ppp) => {
+        console.log(`Applying ppp ${i}`);
+        i++;
+        ppp.cb();
+      });
     }
   ;
 
@@ -679,7 +737,7 @@ SourceCharacter
     { $$ = Char($1, 'oct', @$) }
 
   | DEC_CODE
-    { $$ = GroupRefOrDecChar($1, @$) }
+    { $$ = PreliminaryGroupRef($1, @$) }
 
   | META_CHAR
     { $$ = Char($1, 'meta', @$) }
@@ -688,7 +746,7 @@ SourceCharacter
     { $$ = Char($1, 'meta', @$) }
 
   | NAMED_GROUP_REF
-    { $$ = NamedGroupRefOrChars($1, @1) }
+    { $$ = PreliminaryNamedGroupRef($1, @1) }
 
   ;
 
@@ -781,27 +839,28 @@ CapturingGroup
         throw new SyntaxError(`Duplicate of the named group "${$1}".`);
       }
 
-      capturingGroupsCount++;
-      namedGroups[$1] = capturingGroupsCount;
+      // Record that we've seen this name.
+      namedGroups[$1] = -1;
 
       $$ = Node({
         type: 'Group',
         capturing: true,
         name: $1,
-        number: capturingGroupsCount,
+        number: -1
         expression: $2,
       }, @$)
+      groupRenumberingPass.nodes.append($$);
     }
 
   | L_PAREN Disjunction R_PAREN
     {
-      capturingGroupsCount++;
       $$ = Node({
         type: 'Group',
         capturing: true,
-        number: capturingGroupsCount,
+        number: -1,
         expression: $2,
-      }, @$)
+      }, @$);
+      groupRenumberingPass.nodes.append($$);
     }
   ;
 

--- a/src/parser/regexp.bnf
+++ b/src/parser/regexp.bnf
@@ -196,11 +196,23 @@ let postParsingPasses = [];
 
 let groupRenumberingPass = PostParsingPass(function renumber() {
 	let nextGroupNumber = 1;
+
+  // Renumber capturing groups.
+  // Validate numeric backreferences.
+  // Build a dictionary to update named backreferences.
+  let namedGroups = {};
 	groupRenumberingPass.nodes.forEach((node) => {
+    console.error(`groupRenumberingPass: nextGroupNumber ${nextGroupNumber} node ${JSON.stringify(node)}`);
     // Capturing group: assign the next number.
 		if (node.type === 'Group' && node.capturing) {
+      console.error(`  assigning number ${nextGroupNumber}`);
 			node.number = nextGroupNumber;
 			nextGroupNumber++;
+
+      if (node.name) {
+        console.error(`  named node ${node.name} -> ${node.number}`);
+        namedGroups[node.name] = node;
+      }
 		}
     // Backreference: keep if we've seen the group number, or convert to Char.
     else if (node.type === 'Backreference') {
@@ -208,9 +220,20 @@ let groupRenumberingPass = PostParsingPass(function renumber() {
         if (nextGroupNumber <= node.number) {
           // Reference to a not-yet-seen group.
           // Convert to a Char.
-          node = Char(text, 'decimal', textLoc);
+          node = Char(node.text, 'decimal', node.textLoc);
+        }
+        else {
+          delete node._text;
+          delete node._textLoc;
         }
       }
+      else if (node.kind === 'name') {
+        console.error(`  Getting number for named node ${node.name}`);
+        node.number = namedGroups[node.reference].number;
+      }
+    }
+    else {
+      console.error(`Error, how did I get here?`);
     }
 	});
 });
@@ -230,7 +253,10 @@ let parsingString = '';
 
 yyparse.onParseBegin = (string, lexer) => {
   parsingString = string;
+  // Reset the named groups we've seen.
   namedGroups = {};
+  // Reset the parsing pass nodes.
+  groupRenumberingPass.nodes = [];
 
   const lastSlash = string.lastIndexOf('/');
   const flags = string.slice(lastSlash);
@@ -394,6 +420,8 @@ function PreliminaryGroupRef(text, textLoc) {
     type: 'Backreference',
     kind: 'number',
     number: reference,
+    _text: text,
+    _textLoc: textLoc,
     reference,
   }, textLoc);
 
@@ -579,12 +607,14 @@ RegExp
       }, loc(@1, @4 || @3))
 
       // Apply PostParsingPass's.
+      console.error(`Before any postParsingPasses:\nregex ${JSON.stringify($$, null, 2)}`);
       let i = 0;
       postParsingPasses.forEach((ppp) => {
         console.log(`Applying ppp ${i}`);
         i++;
         ppp.cb();
       });
+      console.error(`After all postParsingPasses:\nregex ${JSON.stringify($$, null, 2)}`);
     }
   ;
 
@@ -846,10 +876,11 @@ CapturingGroup
         type: 'Group',
         capturing: true,
         name: $1,
-        number: -1
+        number: -1,
         expression: $2,
       }, @$)
-      groupRenumberingPass.nodes.append($$);
+      console.error(`Got named capture group: ${$$.name}`);
+      groupRenumberingPass.nodes.push($$);
     }
 
   | L_PAREN Disjunction R_PAREN
@@ -860,7 +891,8 @@ CapturingGroup
         number: -1,
         expression: $2,
       }, @$);
-      groupRenumberingPass.nodes.append($$);
+      console.error(`Got normal capture group`);
+      groupRenumberingPass.nodes.push($$);
     }
   ;
 


### PR DESCRIPTION
Towards #164.

1. Possibly over-engineering. Not sure if there's a need for a "PostParsingPass" concept. But I think it's cleaner.

2. As noted in 5d3682b, I'm not sure how to construct the list of nodes in a way that enables the re-numbering we want, *without* traversing the full tree.

```
=======================
( a ( b ( c ) ) ) d ( e)

Visit order:
3   2   1              4

Desired number order:
1   2   3              4

=======================
( a ) ( b ) ( c ) ( d )

Visit order:
1     2       3      4

Desired number order:
1     2       3      4

=====================

Q: How do we tell whether we are nested or not
during visits?
```

Without a pre/post-hook on parsing steps, I don't see how to address this in the parser at the moment.

Except, of course, via an AST walk.
How concerned are you about the cost of an AST walk? Honestly I can't imagine it will be too expensive.