### PR TITLE
allow a regex to end on the same line as a comment when using /x flag

### DIFF
--- a/src/parser/__tests__/parser-extended-test.js
+++ b/src/parser/__tests__/parser-extended-test.js
@@ -13,9 +13,7 @@ describe('extended', () => {
 
       (?<year>\d{4})-    # year part of a date
       (?<month>\d{2})-   # month part of a date
-      (?<day>\d{2})      # day part of a date
-
-    /x`;
+      (?<day>\d{2})      # day part of a date /x`;
 
     expect(parser.parse(re)).toEqual({
       type: 'RegExp',

--- a/src/parser/generated/regexp-tree.js
+++ b/src/parser/generated/regexp-tree.js
@@ -341,7 +341,7 @@ let tokenizer;
  * See `--custom-tokinzer` to skip this generation, and use a custom one.
  */
 
-const lexRules = [[/^#[^\n]+/, function() { /* skip comments */ }],
+const lexRules = [[/^#[^\n]*(?=\n|\/\w*)/, function() { /* skip comments */ }],
 [/^\s+/, function() { /* skip whitespace */ }],
 [/^\\-/, function() { return 'ESC_CHAR' }],
 [/^-/, function() { return 'DASH' }],

--- a/src/parser/regexp.bnf
+++ b/src/parser/regexp.bnf
@@ -64,7 +64,7 @@ GROUP_NAME              ([\w$]|\\'u'[0-9a-fA-F]{4}|\\'u{'[0-9a-fA-F]{1,}'}')+
 
 %%
 
-<x,xu>'#'[^\n]+                      /* skip comments */
+<x,xu>'#'[^\n]*(?=\n|\/\w*)          /* skip comments */
 <x,xu>\s+                            /* skip whitespace */
 
 <class,u_class>{ESC}'-'              return 'ESC_CHAR'


### PR DESCRIPTION
Looks ahead to be sure ahead there is a newline or the end of the regex. This will close #173.