### PR TITLE
compat-unicode-property-transform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4953,6 +4953,21 @@
       "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
       "dev": true
     },
+    "regenerate-unicode-properties": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
+      "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+      "requires": {
+        "regenerate": "^1.4.0"
+      },
+      "dependencies": {
+        "regenerate": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+          "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
+        }
+      }
+    },
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "prettier": "^1.17.1",
     "shelljs": "^0.7.8",
     "syntax-cli": "^0.1.11"
+  },
+  "dependencies": {
+    "regenerate-unicode-properties": "^8.1.0"
   }
 }

--- a/src/compat-transpiler/transforms/__tests__/compat-unicode-property-transform-test.js
+++ b/src/compat-transpiler/transforms/__tests__/compat-unicode-property-transform-test.js
@@ -31,6 +31,15 @@ describe('compat-unicode-property-transform', () => {
     );
   });
 
+  it('should support single property in character class', () => {
+    const re = transform('/[\\p{ASCII_Hex_Digit}]/u', [
+      compatUnicodePropertyTransform,
+    ]);
+    expect(re.toString()).toBe(
+      '/[\\u0030-\\u0039\\u0041-\\u0046\\u0061-\\u0066]/u'
+    );
+  });
+
   it('should support multiple property in character class', () => {
     const re = transform('/[\\p{ASCII}\\p{ASCII_Hex_Digit}]/u', [
       compatUnicodePropertyTransform,

--- a/src/compat-transpiler/transforms/__tests__/compat-unicode-property-transform-test.js
+++ b/src/compat-transpiler/transforms/__tests__/compat-unicode-property-transform-test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const {transform} = require('../../../transform');
+const compatUnicodePropertyTransform = require('../compat-unicode-property-transform');
+
+describe('compat-unicode-property-transform', () => {
+  it('should support binary property: \\p{ASCII_Hex_Digit}', () => {
+    const re = transform('/\\p{ASCII_Hex_Digit}/u', [
+      compatUnicodePropertyTransform,
+    ]);
+    expect(re.toString()).toBe(
+      '/[\\u0030-\\u0039\\u0041-\\u0046\\u0061-\\u0066]/u'
+    );
+  });
+
+  it('should support binary property negation: \\P{ASCII_Hex_Digit}', () => {
+    const re = transform('/\\P{ASCII_Hex_Digit}/u', [
+      compatUnicodePropertyTransform,
+    ]);
+    expect(re.toString()).toBe(
+      '/[\\u0000-\\u002F\\u003A-\\u0040\\u0047-\\u0060\\u0067-\\u{10FFFF}]/u'
+    );
+  });
+
+  it('should support script property', () => {
+    const re = transform('/\\p{Script=Devanagari}/u', [
+      compatUnicodePropertyTransform,
+    ]);
+    expect(re.toString()).toBe(
+      '/[\\u0900-\\u0950\\u0955-\\u0963\\u0966-\\u097F\\uA8E0-\\uA8FF]/u'
+    );
+  });
+
+  it('should support multiple property in character class', () => {
+    const re = transform('/[\\p{ASCII}\\p{ASCII_Hex_Digit}]/u', [
+      compatUnicodePropertyTransform,
+    ]);
+    expect(re.toString()).toBe(
+      '/[\\u0000-\\u007F\\u0030-\\u0039\\u0041-\\u0046\\u0061-\\u0066]/u'
+    );
+  });
+
+  it('should not run when no "u" flag is inposed', () => {
+    const re = transform('/\\p{ASCII_Hex_Digit}/', [
+      compatUnicodePropertyTransform,
+    ]);
+    expect(re.toString()).toBe('/\\p{ASCII_Hex_Digit}/');
+  });
+});

--- a/src/compat-transpiler/transforms/__tests__/compat-unicode-property-transform-test.js
+++ b/src/compat-transpiler/transforms/__tests__/compat-unicode-property-transform-test.js
@@ -13,6 +13,11 @@ describe('compat-unicode-property-transform', () => {
     );
   });
 
+  it('should support negation of binary property: \\P{ASCII}', () => {
+    const re = transform('/\\P{ASCII}/u', [compatUnicodePropertyTransform]);
+    expect(re.toString()).toBe('/[\\u0080-\\u{10FFFF}]/u');
+  });
+
   it('should support binary property negation: \\P{ASCII_Hex_Digit}', () => {
     const re = transform('/\\P{ASCII_Hex_Digit}/u', [
       compatUnicodePropertyTransform,
@@ -47,6 +52,11 @@ describe('compat-unicode-property-transform', () => {
     expect(re.toString()).toBe(
       '/[\\u0000-\\u007F\\u0030-\\u0039\\u0041-\\u0046\\u0061-\\u0066]/u'
     );
+  });
+
+  it('should support negation of binary property: \\P{Any}', () => {
+    const re = transform('/\\P{Any}/u', [compatUnicodePropertyTransform]);
+    expect(re.toString()).toBe('/[]/u');
   });
 
   it('should not run when no "u" flag is inposed', () => {

--- a/src/compat-transpiler/transforms/compat-unicode-property-transform.js
+++ b/src/compat-transpiler/transforms/compat-unicode-property-transform.js
@@ -10,14 +10,97 @@
  *
  */
 
+function getRegenerateSets(node) {
+  return [
+    'regenerate-unicode-properties',
+    node.binary ? 'Binary_Property' : node.canonicalName,
+    node.binary ? node.canonicalName : node.canonicalValue,
+  ].join('/');
+}
+
+function negateCodepoints(codepoints) {
+  return [0, ...codepoints, 0x110000];
+}
+
+function printCodepoint(codepoint) {
+  if (codepoint < 65536) {
+    return `\\u${codepoint
+      .toString(16)
+      .toUpperCase()
+      .padStart(4, '0')}`;
+  }
+  return `\\u{${codepoint.toString(16).toUpperCase()}}`;
+}
+
+function toCharLiteral(codepoint) {
+  return {
+    type: 'Char',
+    codePoint: codepoint,
+    kind: 'unicode',
+    value: printCodepoint(codepoint),
+    symbol: printCodepoint(codepoint),
+  };
+}
+
+function constructCharacterRange(node) {
+  //fixme: `regenerate.prototype.data` is private API.
+  let codepoints = require(getRegenerateSets(node)).data;
+  if (node.negative) {
+    codepoints = negateCodepoints(codepoints);
+  }
+  const CharacterRange = new Array(codepoints.length / 2);
+  for (let i = 0; i < codepoints.length; i += 2) {
+    if (codepoints[i + 1] - 1 === codepoints[i]) {
+      CharacterRange[i / 2] = toCharLiteral(codepoints[i]);
+    } else {
+      CharacterRange[i / 2] = {
+        type: 'ClassRange',
+        from: toCharLiteral(codepoints[i]),
+        to: toCharLiteral(codepoints[i + 1] - 1),
+      };
+    }
+  }
+
+  return CharacterRange;
+}
+
 module.exports = {
   shouldRun(ast) {
     return ast.flags.includes('u');
   },
-  CharacterClass() {
-    //todo: check unicode property inside character class, replace subarray of CharacterClass expression
+  CharacterClass(path) {
+    const {node} = path;
+    let newExpressions = [];
+    let lastUnicodePropertyIndex = 0;
+    for (let i = 0; i < node.expressions.length; i++) {
+      if (node.expressions[i].type === 'UnicodeProperty') {
+        newExpressions = newExpressions.concat(
+          node.expressions.slice(lastUnicodePropertyIndex + 1, i),
+          constructCharacterRange(node.expressions[i])
+        );
+        lastUnicodePropertyIndex = i;
+      }
+    }
+    if (newExpressions.length === 0) {
+      return;
+    }
+    newExpressions = newExpressions.concat(
+      node.expressions.slice(
+        lastUnicodePropertyIndex + 1,
+        node.expressions.length
+      )
+    );
+
+    path.replace({
+      type: 'CharacterClass',
+      expressions: newExpressions,
+    });
   },
-  UnicodeProperty() {
-    //todo: replace UnicodeProperty by CharacterClass
+  UnicodeProperty(path) {
+    const {node} = path;
+    path.replace({
+      type: 'CharacterClass',
+      expressions: constructCharacterRange(node),
+    });
   },
 };

--- a/src/compat-transpiler/transforms/compat-unicode-property-transform.js
+++ b/src/compat-transpiler/transforms/compat-unicode-property-transform.js
@@ -1,0 +1,23 @@
+/**
+ * The MIT License (MIT)
+ * Copyright (c) 2019-present Junliang Huang <jlhwung@gmail.com>
+ */
+
+'use strict';
+
+/**
+ * A regexp-tree plugin to translate `/\p{ASCII_Hex_Digit}/u` to `/[0-9A-Fa-f]/`.
+ *
+ */
+
+module.exports = {
+  shouldRun(ast) {
+    return ast.flags.includes('u');
+  },
+  CharacterClass() {
+    //todo: check unicode property inside character class, replace subarray of CharacterClass expression
+  },
+  UnicodeProperty() {
+    //todo: replace UnicodeProperty by CharacterClass
+  },
+};

--- a/src/compat-transpiler/transforms/compat-unicode-property-transform.js
+++ b/src/compat-transpiler/transforms/compat-unicode-property-transform.js
@@ -19,7 +19,18 @@ function getRegenerateSets(node) {
 }
 
 function negateCodepoints(codepoints) {
-  return [0, ...codepoints, 0x110000];
+  const newCodepoints = codepoints.slice();
+  if (newCodepoints[0] !== 0) {
+    newCodepoints.unshift(0);
+  } else {
+    newCodepoints.shift();
+  }
+  if (newCodepoints[newCodepoints.length - 1] !== 0x110000) {
+    newCodepoints.push(0x110000);
+  } else {
+    newCodepoints.pop();
+  }
+  return newCodepoints;
 }
 
 function printCodepoint(codepoint) {

--- a/src/compat-transpiler/transforms/compat-unicode-property-transform.js
+++ b/src/compat-transpiler/transforms/compat-unicode-property-transform.js
@@ -34,7 +34,7 @@ function negateCodepoints(codepoints) {
 }
 
 function printCodepoint(codepoint) {
-  if (codepoint < 65536) {
+  if (codepoint <= 0xffff) {
     return `\\u${codepoint
       .toString(16)
       .toUpperCase()

--- a/src/compat-transpiler/transforms/index.js
+++ b/src/compat-transpiler/transforms/index.js
@@ -14,4 +14,7 @@ module.exports = {
 
   // `x` flag
   xFlag: require('./compat-x-flag-transform'),
+
+  // \p{...} and \P{...}
+  unicodeProperties: require('./compat-unicode-property-transform'),
 };


### PR DESCRIPTION
This is a WIP branch on addressing #179.

Above all, I would like to clarify the behavior of this plugin. It would only

- translate the `\p{...}` to the code points corresponding `CharacterClass`.

e.g. `\p{ASCII}` translated to `[\u0000-\u007F]`.
```js
{
      type: 'CharacterClass',
      expressions: [
        {
          type: 'ClassRange',
          from: {
            type: 'Char',
            value: '\\u{0000}',
            kind: 'unicode',
            symbol: '\u0000'
          },
          to: {
            type: 'Char',
            value: '\\u{007F},
            kind: 'unicode',
            symbol: '\u007F',
          }
        }
      ]
    }
```
- translate the `\P{...}` to the complement codepoints CharacterClass,
i.e. `\P{ASCII}` to `[\u0080-\u{10FFFF}]`.

- support `\u` flag only, which means output `\u{10FFFF}` instead of `\uDBFF\uDFFF` surrogate pair. Note: If we would really like to output surrogate pairs, I think there should be another compat transformer to transform code points outside BMP to surrogate pairs.

The transformed result would be far from optimized and the user is expected to leverage the builtin optimizer, i.e. `char-code-to-simple-char-transform`, to process the transformed result so that it can be readable in the eyes of human.

Compared to [`regexpu-core`](https://github.com/mathiasbynens/regexpu-core) which greatly optimizes the resulted transform. This transformer will only focus on transforming property to code points character class.

Another note is that the package separation (discussed [here](https://twitter.com/DmitrySoshnikov/status/1143580731987255296)) is not reflected yet. As introducing `lerna` would bring some devtools changes of this project, I would like to separate the package on phase 2 so that it would not mess up with feature branch.

As the feature is not yet implemented, tests fail as expected.