### PR TITLE
Enable blacklisting of optimizations

### DIFF
--- a/src/optimizer/__tests__/optimizer-integration-test.js
+++ b/src/optimizer/__tests__/optimizer-integration-test.js
@@ -82,8 +82,26 @@ describe('optimizer-integration-test', () => {
     const original = '/(?:[a])/';
     const optimized = '/[a]/';
 
-    expect(optimizer.optimize(original, ['ungroup']).toString()).toBe(
-      optimized.toString()
-    );
+    expect(
+      optimizer.optimize(original, {whitelist: ['ungroup']}).toString()
+    ).toBe(optimized.toString());
+  });
+
+  it('sorts characters', () => {
+    const original = /[åä]/;
+    const optimized = /[äå]/;
+
+    expect(optimizer.optimize(original).toString()).toBe(optimized.toString());
+  });
+
+  it('preserves character order when blacklisted charClassClassrangesMerge', () => {
+    const original = /[åä]/;
+    const optimized = /[åä]/;
+
+    expect(
+      optimizer
+        .optimize(original, {blacklist: ['charClassClassrangesMerge']})
+        .toString()
+    ).toBe(optimized.toString());
   });
 });

--- a/src/optimizer/index.js
+++ b/src/optimizer/index.js
@@ -27,11 +27,13 @@ module.exports = {
    *
    *   /\w+e+/
    */
-  optimize(regexp, transformsWhitelist = []) {
-    const transformToApply =
-      transformsWhitelist.length > 0
-        ? transformsWhitelist
-        : Object.keys(optimizationTransforms);
+  optimize(regexp, {whitelist = [], blacklist = []} = {}) {
+    const transformsRaw =
+      whitelist.length > 0 ? whitelist : Object.keys(optimizationTransforms);
+
+    const transformToApply = transformsRaw.filter(
+      transform => !blacklist.includes(transform)
+    );
 
     let ast = regexp;
     if (regexp instanceof RegExp) {

--- a/src/regexp-tree.js
+++ b/src/regexp-tree.js
@@ -68,9 +68,9 @@ const regexpTree = {
    *       ...
    *     },
    *   });
-	 *
-	 * The value for a node type may also be an object with functions pre and post.
-	 * This enables more context-aware analyses, e.g. measuring star height.
+   *
+   * The value for a node type may also be an object with functions pre and post.
+   * This enables more context-aware analyses, e.g. measuring star height.
    */
   traverse(ast, handlers, options) {
     return traverse.traverse(ast, handlers, options);
@@ -123,8 +123,8 @@ const regexpTree = {
    *
    * @return TransformResult object
    */
-  optimize(regexp, whitelist) {
-    return optimizer.optimize(regexp, whitelist);
+  optimize(regexp, whitelist, {blacklist} = {}) {
+    return optimizer.optimize(regexp, {whitelist, blacklist});
   },
 
   /**


### PR DESCRIPTION
Makes it easier to disable some optimizations, as requested in eg. #199. Also adds some specific tests for one of the feature that's highlighted in #199 and is a partial fix for that issue.