### PR TITLE
Optimize API differences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regexp-tree",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/optimizer/README.md
+++ b/src/optimizer/README.md
@@ -25,6 +25,10 @@ becomes:
 
 `optimize(regexp, {whitelist: [transformsWhitelist], blacklist: [transformsWhitelist]})`: Optimize the regexp. Optionally request specific transforms.
 
+Note that this API of the optimizer differs from the API of `regexp-tree`'s `optimize`
+method which instead expects its first argument to be an array (the `whitelist`) and
+its second argument as an object with `blacklist` as a property.
+
 Transforms will be applied until no further optimization progress is made.
 
 If you wish to specify a whitelist, give an array of transform names from the table below.


### PR DESCRIPTION
Builds on #204 .

- Docs: Note difference between `regexp-tree` main `optimize` method and the optimizer method (esp. since `regexp-tree` README defers to this README)

