### PR TITLE
Fix `\s` rewrite

### DIFF
--- a/src/optimizer/__tests__/optimizer-integration-test.js
+++ b/src/optimizer/__tests__/optimizer-integration-test.js
@@ -59,14 +59,14 @@ describe('optimizer-integration-test', () => {
   });
 
   it('whitespace', () => {
-    const original = /[ \n\r\t\f]+/;
+    const original = /[ \f\n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]+/;
     const optimized = /\s+/;
 
     expect(optimizer.optimize(original).toString()).toBe(optimized.toString());
   });
 
   it('whitespace group', () => {
-    const original = /[ \n\t\r\]]/g;
+    const original = /[ \f\n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff\]]/g;
     const optimized = /[\s\]]/g;
 
     expect(optimizer.optimize(original).toString()).toBe(optimized.toString());

--- a/src/optimizer/transforms/__tests__/char-class-to-meta-transform-test.js
+++ b/src/optimizer/transforms/__tests__/char-class-to-meta-transform-test.js
@@ -9,40 +9,57 @@ const {transform} = require('../../../transform');
 const charClassToMeta = require('../char-class-to-meta-transform');
 
 describe('char-class-to-meta', () => {
-
   it('replaces number ranges', () => {
-    const re = transform(/[0-9$]/, [
-      charClassToMeta,
-    ]);
+    const re = transform(/[0-9$]/, [charClassToMeta]);
     expect(re.toString()).toBe('/[\\d$]/');
   });
 
   it('replaces word ranges', () => {
-    const re = transform(/[0-9a-zA-Z_$]/, [
-      charClassToMeta,
-    ]);
+    const re = transform(/[0-9a-zA-Z_$]/, [charClassToMeta]);
     expect(re.toString()).toBe('/[\\w$]/');
   });
 
   it('replaces word ranges when regexp has i flag', () => {
-    const re = transform(/[0-9a-z_$]/i, [
-      charClassToMeta,
-    ]);
+    const re = transform(/[0-9a-z_$]/i, [charClassToMeta]);
     expect(re.toString()).toBe('/[\\w$]/i');
   });
 
   it('replaces word ranges when regexp has i and u flags', () => {
-    const re = transform('/[\\da-zA-Z_\\u017F\\u212A$]/iu', [
-      charClassToMeta,
-    ]);
+    const re = transform('/[\\da-zA-Z_\\u017F\\u212A$]/iu', [charClassToMeta]);
     expect(re.toString()).toBe('/[\\w$]/iu');
   });
 
   it('whitespace ranges', () => {
-    const re = transform(/[ \t\r\n\f]/, [
-      charClassToMeta,
-    ]);
+    const re = transform(
+      /[ \f\n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]/,
+      [charClassToMeta]
+    );
     expect(re.toString()).toBe('/[\\s]/');
   });
 
+  it('whitespace ranges order do not matters', () => {
+    const re = transform(
+      /[\f \n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]/,
+      [charClassToMeta]
+    );
+    expect(re.toString()).toBe('/[\\s]/');
+  });
+
+  it('whitespace ranges duplicated chars', () => {
+    const re = transform(
+      /[ \f\n\n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]/,
+      [charClassToMeta]
+    );
+    expect(re.toString()).toBe('/[\\s]/');
+  });
+
+  it('whitespace ranges missing chars', () => {
+    const re = transform(
+      /[ \n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]/,
+      [charClassToMeta]
+    );
+    expect(re.toString()).toBe(
+      '/[ \\n\\r\\t\\v\\u00a0\\u1680\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff]/'
+    );
+  });
 });


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes#Types), `[\s]` should equivalent to `[ \f\n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]`