### PR TITLE
Allow /[a\-z]/u to parse without error

### DIFF
--- a/src/parser/__tests__/parser-basic-test.js
+++ b/src/parser/__tests__/parser-basic-test.js
@@ -135,6 +135,38 @@ describe('basic', () => {
       },
       flags: 'i',
     });
+
+    expect(re(/[a\-z]/u)).toEqual({
+      type: 'RegExp',
+      body: {
+        type: 'CharacterClass',
+        expressions: [
+          {
+            type: 'Char',
+            value: 'a',
+            symbol: 'a',
+            kind: 'simple',
+            codePoint: 'a'.codePointAt(0),
+          },
+          {
+            type: 'Char',
+            value: '-',
+            symbol: '-',
+            kind: 'simple',
+            escaped: true,
+            codePoint: '-'.codePointAt(0),
+          },
+          {
+            type: 'Char',
+            value: 'z',
+            symbol: 'z',
+            kind: 'simple',
+            codePoint: 'z'.codePointAt(0),
+          },
+        ],
+      },
+      flags: 'u',
+    });
   });
 
   it('empty class', () => {

--- a/src/parser/generated/regexp-tree.js
+++ b/src/parser/generated/regexp-tree.js
@@ -374,7 +374,10 @@ const lexRules = [[/^#[^\n]+/, function() { /* skip comments */ }],
 [/^\\[\^\$\.\*\+\?\(\)\\\[\]\{\}\|\/]/, function() { return 'ESC_CHAR' }],
 [/^\\[^*?+\[()\\|]/, function() { 
                                       const s = this.getCurrentState();
-                                      if (s === 'u' || s === 'xu' || s === 'u_class') {
+                                      if (s === 'u_class' && yytext === "\\-") {
+                                        return 'ESC_CHAR';
+                                      }
+                                      else if (s === 'u' || s === 'xu' || s === 'u_class') {
                                         throw new SyntaxError(`invalid Unicode escape ${yytext}`);
                                       }
                                       return 'ESC_CHAR';


### PR DESCRIPTION
This fixes #218 by implementing the solution from @andruo11