### PR TITLE
Fix #227: treat "any single character" token as special in groupSingleCharsToCharClass

### DIFF
--- a/src/optimizer/__tests__/optimizer-integration-test.js
+++ b/src/optimizer/__tests__/optimizer-integration-test.js
@@ -145,4 +145,14 @@ describe('optimizer-integration-test', () => {
         .toString()
     ).toBe(optimized.toString());
   });
+
+  [
+    /(?:.|\s)*/,
+    /^import ((?:.|\s)*?) from "(.*)";/gm,
+    /(.|[\n\r])/, // from https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1231#issue-870010385
+  ].map(regexp =>
+    it(`can recognise dot as "any single character" token in ${regexp}`, () => {
+      expect(optimizer.optimize(regexp).toString()).toBe(regexp.toString());
+    })
+  );
 });

--- a/src/optimizer/transforms/__tests__/group-single-chars-to-char-class-test.js
+++ b/src/optimizer/transforms/__tests__/group-single-chars-to-char-class-test.js
@@ -44,6 +44,11 @@ describe('(a|b|c) -> ([abc])', () => {
     expect(re.toString()).toBe('/(a|b|no)/');
   });
 
+  it('have no effect on "any single character" token', () => {
+    const re = transform(/(\r|\n|.)/, [singleCharsGroupToCharClass]);
+    expect(re.toString()).toBe(/(\r|\n|.)/.toString());
+  });
+
   it('has no effet on empty values', () => {
     const re = transform(/(a|b|)/, [singleCharsGroupToCharClass]);
     expect(re.toString()).toBe('/(a|b|)/');

--- a/src/optimizer/transforms/group-single-chars-to-char-class.js
+++ b/src/optimizer/transforms/group-single-chars-to-char-class.js
@@ -69,6 +69,10 @@ function shouldProcess(expression, charset) {
 
     return shouldProcess(left, charset) && shouldProcess(right, charset);
   } else if (type === 'Char') {
+    if (expression.kind === 'meta' && expression.symbol === '.') {
+      return false;
+    }
+
     const {value} = expression;
 
     charset.set(value, expression);


### PR DESCRIPTION
Fixes https://github.com/DmitrySoshnikov/regexp-tree/issues/227
and fixes https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1231