### PR TITLE
fix: add support for `hasIndices` `/d` regex flag

### DIFF
--- a/src/compat-transpiler/runtime/index.js
+++ b/src/compat-transpiler/runtime/index.js
@@ -48,6 +48,7 @@ class RegExpTree {
     this.multiline = re.multiline;
     this.sticky = re.sticky;
     this.unicode = re.unicode;
+    this.hasIndices = re.hasIndices;
   }
 
   /**

--- a/src/parser/__tests__/parser-basic-test.js
+++ b/src/parser/__tests__/parser-basic-test.js
@@ -1076,6 +1076,22 @@ describe('basic', () => {
     });
   });
 
+  it('hasIndices (/d) flag', () => {
+    // Warning: Only supported in ES2022 or later (Node.JS v16)\
+    // Not using `re` helper here, since ESLint is only setup for ES6.
+    expect(parser.parse('/a/d')).toEqual({
+      type: 'RegExp',
+      body: {
+        type: 'Char',
+        value: 'a',
+        symbol: 'a',
+        kind: 'simple',
+        codePoint: 'a'.codePointAt(0),
+      },
+      flags: 'd',
+    });
+  });
+
   it('throws error on invalid Unicode escape', () => {
     expect(() => parser.parse('/\\p/u')).toThrowError(SyntaxError);
     expect(() => parser.parse('/\\e/u')).toThrowError(SyntaxError);

--- a/src/parser/generated/regexp-tree.js
+++ b/src/parser/generated/regexp-tree.js
@@ -1066,7 +1066,7 @@ function Char(value, kind, loc) {
  * Valid flags per current ECMAScript spec and
  * stage 3+ proposals.
  */
-const validFlags = 'gimsuxy';
+const validFlags = 'gimsuxyd';
 
 /**
  * Checks the flags are valid, and that

--- a/src/parser/regexp.bnf
+++ b/src/parser/regexp.bnf
@@ -405,7 +405,7 @@ function Char(value, kind, loc) {
  * Valid flags per current ECMAScript spec and
  * stage 3+ proposals.
  */
-const validFlags = 'gimsuxy';
+const validFlags = 'gimsuxyd';
 
 /**
  * Checks the flags are valid, and that


### PR DESCRIPTION
The `hasIndices` or `/d` regex flag is part of ES2022.

> The `d` flag indicates that the result of a regular expression match should contain the start and end indices of the substrings of each capture group. It does not change the regex's interpretation or matching behavior in any way, but only provides additional information in the matching result.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/hasIndices