### PR TITLE
Optimizer: fix quantifier merge transform

### DIFF
--- a/src/optimizer/README.md
+++ b/src/optimizer/README.md
@@ -75,7 +75,7 @@ Here is the list of transforms supported by the Optimizer module.
 | charCodeToSimpleChar                                  | Don't use fancy char codes unless we have to                   | `\u0061` -> `a`               |
 | charCaseInsensitiveLowerCaseTransform                 | If regex is case insensitive, use lower-case everywhere        |  `/Aa/i` -> `/aa/i`           |
 | charClassRemoveDuplicates                             | Remove duplicates from char classes                            |  `[\d\d]` -> `[\d]`           |
-| quantifiersMerge                                      | Merge quantifiers where possible                               |  `a{1,2}a{2,3}` -> `a{3,5}`   |
+| quantifiersMerge                                      | Merge quantifiers where possible                               |  `a{1,2}a{0,3}` -> `a{1,5}`   |
 | quantifierRangeToSymbol                               | Reduce visual of quantifier ranges                             |  `a{1,}` -> `a+`              |
 | charClassClassrangesToChars                           | Replace char class ranges with chars                           |  `[a-a]` -> `[a]`             |
 | charClassClassrangesMerge                             | Merge adjacent class ranges                                    |  `[a-de-f]` -> `[a-f]`        |

--- a/src/optimizer/transforms/quantifiers-merge-transform.js
+++ b/src/optimizer/transforms/quantifiers-merge-transform.js
@@ -10,9 +10,9 @@ const {increaseQuantifierByOne} = require('../../transform/utils');
 /**
  * A regexp-tree plugin to merge quantifiers
  *
- * a+a+ -> a{2,}
+ * a{2}a+ ->
  * a{2}a{3} -> a{5}
- * a{1,2}a{2,3} -> a{3,5}
+ * a{1,2}a{0,3} -> a{1,5}
  */
 module.exports = {
 
@@ -69,10 +69,10 @@ module.exports = {
           return;
         }
       } else {
-        // r{n1,m1}r{n2} -> r{n1+n2,m2+n2}
-        // r{n1,m1}?r{n2} -> r{n1+n2,m2+n2}?
-        // r{n1,m1}r{n2}? -> r{n1+n2,m2+n2}
-        // r{n1,m1}?r{n2}? -> r{n1+n2,m2+n2}?
+        // r{n1,m1}r{n2} -> r{n1+n2,m1+n2}
+        // r{n1,m1}?r{n2} -> r{n1+n2,m1+n2}?
+        // r{n1,m1}r{n2}? -> r{n1+n2,m1+n2}
+        // r{n1,m1}?r{n2}? -> r{n1+n2,m1+n2}?
         if (nodeTo == nodeFrom) {
           makeQuantifier(node, previousSiblingFrom + nodeFrom, previousSiblingTo, nodeTo, previousSiblingGreedy);
           previousSibling.remove();

--- a/src/traverse/node-path.js
+++ b/src/traverse/node-path.js
@@ -305,6 +305,24 @@ class NodePath {
   }
 
   /**
+   * Indicates if the matching direction is forward.
+   *
+   * This means that the deepest lookaround of the path is not a
+   * lookbehind. This ensures that the current node will be
+   * matched in the forward direction.
+   */
+  isForward() {
+    let currentNodePath = this.parentPath;
+
+    if (!currentNodePath || currentNodePath.node.kind == 'Lookahead') {
+      return true;
+    }
+
+    return (currentNodePath.node.kind !== 'Lookbehind' && currentNodePath.isForward());
+  }
+
+
+  /**
    * Returns a NodePath instance for a node.
    *
    * The same NodePath can be reused in several places, e.g.

--- a/src/traverse/node-path.js
+++ b/src/traverse/node-path.js
@@ -305,24 +305,6 @@ class NodePath {
   }
 
   /**
-   * Indicates if the matching direction is forward.
-   *
-   * This means that the deepest lookaround of the path is not a
-   * lookbehind. This ensures that the current node will be
-   * matched in the forward direction.
-   */
-  isForward() {
-    let currentNodePath = this.parentPath;
-
-    if (!currentNodePath || currentNodePath.node.kind == 'Lookahead') {
-      return true;
-    }
-
-    return (currentNodePath.node.kind !== 'Lookbehind' && currentNodePath.isForward());
-  }
-
-
-  /**
    * Returns a NodePath instance for a node.
    *
    * The same NodePath can be reused in several places, e.g.


### PR DESCRIPTION
This PR addresses the issue https://github.com/DmitrySoshnikov/regexp-tree/issues/267 .

In some cases, the current quantifiers merge transform is incorrect.
This PR makes sure that the merging of quantifiers is only applied in cases that are known to be correct.

## When is quantifier merging correct?

We studied this problem recently in the following paper: https://arxiv.org/abs/2507.13091 .
Section 5 establishes conditions for which we proved that the optimization is correct.
Appendix B establishes counter-examples when these conditions aren't met.

From these results, we can establish 4 cases for when to perform the quantifier merge:
- When matching forward and the first quantifier is a forced quantifier (meaning that there are as many maximum iterations as minimum iterations, e.g. `a{4}`)
- When matching forward, both quantifiers are greedy, and the minimum iterations of the second quantifier is 0.
- When matching backward, and the second quantifier is a forced quantifier.
- When matching backwardn both quantifiers are greedy, and the minimum iterations of the first quantifier is 0.

Interestingly, this depends on the matching direction.
This means that we do not perform the same optimization when inside a lookbehind, or inside a lookahead (hence the `isForward` function).

## Correctness proofs

We wrote Rocq proofs, establishing that in these 4 cases it is correct to perform the optimization.

These proofs are available here: https://github.com/epfl-systemf/Linden/blob/f3c94efb9d5437073d65339c86d898ba669709e3/Rewriting/RegexpTree.v#L526-L640 .

## Work in Progress

This PR is still a draft, because this new version is still too restrictive: it should be possible to apply the optimization in more cases.
For instance, many tests in https://github.com/DmitrySoshnikov/regexp-tree/blob/master/src/optimizer/transforms/__tests__/quantifiers-merge-transform-test.js are now failing. And yet, in all of these cases, it should be correct to apply the optimization.

This is because the regex being quantified (only `a` in these tests) is non-ambiguous.
In such cases we believe that merging quantifiers is always correct.
My plan is to prove that this is correct, then implement a small non-ambiguity analysis and use it to perform the optimization more often.
