### PR TITLE
fix(generator): escape leading caret in non-negative character class

### DIFF
--- a/src/generator/__tests__/generator-basic-test.js
+++ b/src/generator/__tests__/generator-basic-test.js
@@ -123,6 +123,20 @@ describe('generator-basic', () => {
     test(/[^]/);
   });
 
+  it('escapes a leading `^` in a non-negative character class', () => {
+    // An AST whose first class member is a literal `^` (e.g. after a
+    // transform reorders `[a^]`) must be generated as `[\^a]`, otherwise
+    // `[^a]` would be read back as a negative class.
+    const ast = parser.parse('/[a^]/');
+    ast.body.expressions.reverse();
+    const generated = generator.generate(ast);
+    expect(generated).toBe('/[\\^a]/');
+
+    // The escaped output round-trips to a non-negative class.
+    const reparsed = parser.parse(generated);
+    expect(reparsed.body.negative).toBeFalsy();
+  });
+
   it('positive lookahead assertion', () => {
     test(/(?=abc)/);
   });

--- a/src/generator/index.js
+++ b/src/generator/index.js
@@ -88,13 +88,23 @@ const generator = {
   },
 
   CharacterClass(node) {
-    const expressions = node.expressions.map(gen).join('');
+    const expressions = node.expressions.map(gen);
 
-    if (node.negative) {
-      return `[^${expressions}]`;
+    // A non-negative class whose first element is a literal `^` must escape
+    // it, otherwise the generated `[^...]` is parsed back as a negative class.
+    // This surfaces when a transform reorders the class (e.g. the optimizer
+    // sorting `[a^]` into `[^a]`) or when generating from a hand-built AST.
+    if (!node.negative && isLeadingCaret(node.expressions[0])) {
+      expressions[0] = '\\' + expressions[0];
     }
 
-    return `[${expressions}]`;
+    const body = expressions.join('');
+
+    if (node.negative) {
+      return `[^${body}]`;
+    }
+
+    return `[${body}]`;
   },
 
   ClassRange(node) {
@@ -173,6 +183,20 @@ const generator = {
     return `\\${escapeChar}{${namePart}${node.value}}`;
   },
 };
+
+/**
+ * Whether a node is an unescaped literal `^` char, which is special when it
+ * appears first in a non-negative character class.
+ */
+function isLeadingCaret(node) {
+  return (
+    node != null &&
+    node.type === 'Char' &&
+    node.kind === 'simple' &&
+    node.value === '^' &&
+    !node.escaped
+  );
+}
 
 module.exports = {
   /**

--- a/src/optimizer/transforms/__tests__/char-class-classranges-merge-transform-test.js
+++ b/src/optimizer/transforms/__tests__/char-class-classranges-merge-transform-test.js
@@ -189,4 +189,25 @@ describe('char-class-classranges-merge', () => {
     expect(re.toString()).toBe('/[<=>?]/');
   });
 
+  it('keeps a `^` sorted to the front escaped, not turning the class negative', () => {
+    // `^` (0x5e) sorts before `a` (0x61), so the class is reordered to put
+    // `^` first. The leading `^` must be escaped, otherwise `[^a]` would be a
+    // negative class matching the opposite set.
+    let re = transform(/[a^]/, [
+      charClassClassrangesMerge,
+    ]);
+    expect(re.toString()).toBe('/[\\^a]/');
+
+    re = transform(/[a^bc]/, [
+      charClassClassrangesMerge,
+    ]);
+    expect(re.toString()).toBe('/[\\^a-c]/');
+
+    // A genuine negative class is left untouched.
+    re = transform(/[^a]/, [
+      charClassClassrangesMerge,
+    ]);
+    expect(re.toString()).toBe('/[^a]/');
+  });
+
 });


### PR DESCRIPTION
`regexp-tree.optimize('/[a^]/')` returns `/[^a]/`, which inverts the regex: `[a^]` matches `a` or `^`, while `[^a]` matches everything except `a`.

The optimizer's `charClassClassrangesMerge` sorts character-class members by code point, and `^` (U+005E) sorts before `a` (U+0061), so the class is reordered to put `^` first. The generator's `CharacterClass` handler emits the members verbatim, so the reordered class is written as `[^a]`, and a leading `^` in a class is parsed back as negation.

It is more visible when the reordered class is short enough for the optimizer to keep:

```
optimize('/[a^bcdef]/')   was  /[^a-f]/   (negated, wrong)
                          now  /[\^a-f]/
```

The same path is reachable through the public `generate()` API: building or transforming an AST so that a non-negative class starts with a literal `^` produces an inverted regex today.

The fix is in the generator: when a character class is not negative and its first member is an unescaped literal `^`, escape it. `[a^]` then round-trips correctly, and `optimize('/[a^]/')` returns `/[a^]/` again. Genuine negative classes and an already-escaped `[\^a]` are unaffected.

Tests added for the generator and for the `char-class-classranges-merge` transform. The full `src` suite passes.
